### PR TITLE
Code Cleanup.

### DIFF
--- a/src/nexrad/NexRadLevel3.zig
+++ b/src/nexrad/NexRadLevel3.zig
@@ -38,7 +38,6 @@ radial_starts: []f64 = undefined,
 radial_deltas: []f64 = undefined,
 num_radials: u32 = undefined,
 num_data_points: usize = 0,
-radial_affinity: []u32 = undefined,
 index_of_first_range_bin: i16 = undefined,
 product_code: i16 = 94,
 range_scale_factor: f32 = 0.0,
@@ -143,7 +142,6 @@ fn decodeDigitalRadialProduct(self: *Self, reader: anytype) !void {
     self.radial_data = try allocator.alloc(u8, self.num_range_bins * self.num_radials);
     self.radial_starts = try allocator.alloc(f64, self.num_radials);
     self.radial_deltas = try allocator.alloc(f64, self.num_radials);
-    self.radial_affinity = try allocator.alloc(u32, self.num_range_bins * self.num_radials);
 
     var expected_byte_count: u16 = 0;
     var read_head: usize = 0;
@@ -169,7 +167,6 @@ fn decodeDigitalRadialProduct(self: *Self, reader: anytype) !void {
             read_head += @intCast(self.num_range_bins - expected_byte_count);
         }
 
-        @memset(self.radial_affinity[read_head .. read_head + self.num_range_bins], @intCast(radial));
         read_head += bytes_read;
     }
 

--- a/src/ui/color_tables/Manager.zig
+++ b/src/ui/color_tables/Manager.zig
@@ -179,7 +179,7 @@ fn importColorTableFromReader(self: *Self, reader: anytype) !*lib.AutoBoxed(Entr
     });
 
     entry.value.product = defs.ProductCodeToAssociation.get(
-        entry.value.table.product.slice(),
+        entry.value.table.product.constSlice(),
     ) orelse .BaseReflectivity;
 
     entry.value.table.populateLookupTable(

--- a/src/ui/nexrad_layer.zig
+++ b/src/ui/nexrad_layer.zig
@@ -242,10 +242,7 @@ pub const NexradLayer = struct {
         c.gtk_widget_queue_draw(@ptrCast(self));
     }
 
-    ///
     /// Takes the currently loaded radar image and draws the radial data to the internal radar surface.
-    ///
-    ///
     fn redrawRadarTexture(self: *Self, radar_data: *nexrad.NexradLevel3) !void {
         const surface_size: f64 = @floatFromInt(self.internal_surface_size);
         const surface_diameter: f64 = @as(f64, @floatFromInt(radar_data.num_range_bins)) * 2.0;
@@ -273,12 +270,14 @@ pub const NexradLayer = struct {
         c.cairo_scale(context, scale_fac, scale_fac);
 
         var range_bin: u64 = 0;
+        var radial: u64 = 0;
         for (
             radar_data.radial_data[0..radar_data.num_data_points],
-            radar_data.radial_affinity[0..radar_data.num_data_points],
             0..,
-        ) |data, radial, i| {
+        ) |data, i| {
             range_bin = i % @as(u64, @intCast(radar_data.num_range_bins));
+            radial += @intFromBool(i > 0 and range_bin == 0);
+
             if (data == 0) {
                 continue;
             }


### PR DESCRIPTION
  - Get rid of useless `NexRadLevel3.radial_affinity` field.
  - Clean up string handling in ColorTable.
  - Use `BoundedArray.constSlice` wherever possible.