### PR TITLE
Add more rigorous testing & refactor.

### DIFF
--- a/src/nexrad.zig
+++ b/src/nexrad.zig
@@ -26,6 +26,7 @@ pub const utilities = @import("nexrad/utilities.zig");
 pub const io = @import("nexrad/io.zig");
 pub const definitions = @import("nexrad/definitions.zig");
 pub const products = @import("nexrad/products.zig");
+pub const models = @import("nexrad/models.zig");
 
 test {
     _ = @import("nexrad/definitions.zig");


### PR DESCRIPTION
  - Parsing: Add tests around parsing radial products.
  - Cleanup: Refactor ColorTable.zig to remove old `.populateLookupTable`.