### PR TITLE
[#9] Add support for N0X

### DIFF
--- a/src/assets/bundled_assets.zig
+++ b/src/assets/bundled_assets.zig
@@ -21,6 +21,7 @@ pub const color_tables = struct {
     pub const nexrad_l3_p99 = @embedFile("nexrad_l3_p99.wctpal");
     pub const nexrad_l3_p161 = @embedFile("nexrad_l3_p161.wctpal");
     pub const nexrad_l3_p135 = @embedFile("nexrad_l3_p135.wctpal");
+    pub const nexrad_l3_p159 = @embedFile("nexrad_l3_p159.wctpal");
 };
 
 pub const license = @embedFile("license_statement.txt");

--- a/src/assets/nexrad_l3_p159.wctpal
+++ b/src/assets/nexrad_l3_p159.wctpal
@@ -1,0 +1,19 @@
+# NEXRAD Level-3 palette for product code 159, NnX, Diff. Reflect, ZDR
+
+Units: DB
+Product: DR
+
+Color:  -7.9     0   0    0
+Color:   0.0   220 220  220
+Color:   0.0   142 121  181
+Color:   0.25    10  10  155
+Color:   1.0    68 248  212
+Color:   1.5    90 221   98
+Color:   2.0   255 255  100
+Color:   3.0   220  10    5
+Color:   4.0   175   0    0
+Color:   5.0   240 120  180
+Color:   6.0   255 255  255
+Color:   7.9   145  45  150
+
+# Unique: 800 "RF"    119   0  125

--- a/src/nexrad/products.zig
+++ b/src/nexrad/products.zig
@@ -5,6 +5,7 @@ pub const friendly_names: []const [:0]const u8 = &.{
     "Base Velocity",
     "Correlation Coefficient",
     "Enhanced Echo Tops",
+    "Differential Reflectivity",
 };
 
 pub const Product = struct {
@@ -18,32 +19,32 @@ pub const Product = struct {
     }
 };
 
-pub const standard_products: []const Product = &.{
-    .{
-        .friendly_name_id = 0,
-        .code_name = "N0Q".*,
-        .tilt_digit_index = 1,
-        .tilt_levels = 4,
-    },
-    .{
-        .friendly_name_id = 1,
-        .code_name = "NOU".*,
-        .tilt_digit_index = 1,
-        .tilt_levels = 4,
-    },
-    .{
-        .friendly_name_id = 2,
-        .code_name = "N0C".*,
-        .tilt_digit_index = 1,
-        .tilt_levels = 4,
-    },
-    .{
-        .friendly_name_id = 3,
-        .code_name = "EET".*,
-        .tilt_digit_index = 0,
-        .tilt_levels = 1,
-    },
-};
+pub const standard_products: []const Product = &.{ .{
+    .friendly_name_id = 0,
+    .code_name = "N0Q".*,
+    .tilt_digit_index = 1,
+    .tilt_levels = 4,
+}, .{
+    .friendly_name_id = 1,
+    .code_name = "NOU".*,
+    .tilt_digit_index = 1,
+    .tilt_levels = 4,
+}, .{
+    .friendly_name_id = 2,
+    .code_name = "N0C".*,
+    .tilt_digit_index = 1,
+    .tilt_levels = 4,
+}, .{
+    .friendly_name_id = 3,
+    .code_name = "EET".*,
+    .tilt_digit_index = 0,
+    .tilt_levels = 1,
+}, .{
+    .friendly_name_id = 4,
+    .code_name = "N0X".*,
+    .tilt_digit_index = 1,
+    .tilt_levels = 4,
+} };
 
 pub const tdwr_products: []const Product = &.{
     .{

--- a/src/ui/color_tables/definitions.zig
+++ b/src/ui/color_tables/definitions.zig
@@ -20,6 +20,7 @@ pub const ProductAssociation = enum {
     BaseVelocity,
     CorrelationCoefficient,
     EnhancedEchoTops,
+    DifferentialReflectivity,
 };
 
 pub const ProductCodeToAssociation = std.StaticStringMap(ProductAssociation).initComptime(
@@ -28,17 +29,19 @@ pub const ProductCodeToAssociation = std.StaticStringMap(ProductAssociation).ini
         .{ "BV", .BaseVelocity },
         .{ "CC", .CorrelationCoefficient },
         .{ "EET", .EnhancedEchoTops },
+        .{ "DR", .DifferentialReflectivity },
     },
 );
 
 /// Static ranges, deprecated as static ranges are the "old way" of decoding values.
-/// The new data level decoding scheme will use dynamic LUTs to support more accurate\
+/// The new data level decoding scheme will use dynamic LUTs to support more accurate
 /// conversion of data, at the cost of a little performance.
 pub const Ranges: [@typeInfo(ProductAssociation).@"enum".fields.len]struct { f32, f32 } = .{
     .{ -32.0, 95.0 },
     .{ -247.0, 245.0 },
     .{ 0.2, 1.05 },
     .{ 0.0, 75.0 },
+    .{ -8.0, 8.0 },
 };
 
 pub const number_of_products = std.enums.values(ProductAssociation).len;

--- a/src/ui/nexrad_layer.zig
+++ b/src/ui/nexrad_layer.zig
@@ -200,7 +200,7 @@ pub const NexradLayer = struct {
         self.radar_longitude = radar_data.radar_longitude;
         self.radial_length_meters = switch (radar_data.product_code) {
             94 => 230000.0,
-            99, 161 => 150012.1,
+            99, 159, 161 => 150012.1,
             180, 182 => 44448.02,
             135 => 172236.1,
             else => 0.0,
@@ -255,6 +255,7 @@ pub const NexradLayer = struct {
             99, 182 => .BaseVelocity,
             161 => .CorrelationCoefficient,
             135 => .EnhancedEchoTops,
+            159 => .DifferentialReflectivity,
             else => .BaseReflectivity,
         };
 
@@ -310,7 +311,6 @@ pub const NexradLayer = struct {
                 (radar_data.radial_starts[radial] * std.math.pi / 180.0) - 2.0 * std.math.pi / 4.0,
             );
             c.cairo_close_path(context);
-
             const color = lut[@as(usize, @intCast(data))];
             c.cairo_set_source_rgba(
                 context,


### PR DESCRIPTION
Adds support for the N0X (PC #159, Differential Reflectivity) product. This product is important for hail detection, among other things.