### PR TITLE
[#9] Add N0K product.

### DIFF
--- a/src/assets/bundled_assets.zig
+++ b/src/assets/bundled_assets.zig
@@ -22,6 +22,7 @@ pub const color_tables = struct {
     pub const nexrad_l3_p161 = @embedFile("nexrad_l3_p161.wctpal");
     pub const nexrad_l3_p135 = @embedFile("nexrad_l3_p135.wctpal");
     pub const nexrad_l3_p159 = @embedFile("nexrad_l3_p159.wctpal");
+    pub const nexrad_l3_p163 = @embedFile("nexrad_l3_p163.wctpal");
 };
 
 pub const license = @embedFile("license_statement.txt");

--- a/src/assets/nexrad_l3_p163.wctpal
+++ b/src/assets/nexrad_l3_p163.wctpal
@@ -1,0 +1,16 @@
+# NEXRAD Level-3 palette for product code 163, NxK, Spec. Diff. Phase
+
+Product: SDP
+Units: DEG
+
+Color:   -2.05   255  255  255
+Color:  0.83   210  210  180
+Color:  1.67    10   20   95
+Color:  2.5     0  255    0
+Color:  3.33    30  100    0
+Color:  4.17   255  255    0
+Color:  5.00   255  125    0
+Color:  6.67    90    0    0
+Color:  10.0   255  140  255
+
+# Unique: 800 "RF"    119   0  125

--- a/src/nexrad/products.zig
+++ b/src/nexrad/products.zig
@@ -6,6 +6,7 @@ pub const friendly_names: []const [:0]const u8 = &.{
     "Correlation Coefficient",
     "Enhanced Echo Tops",
     "Differential Reflectivity",
+    "Specific Differential Phase",
 };
 
 pub const Product = struct {
@@ -19,32 +20,44 @@ pub const Product = struct {
     }
 };
 
-pub const standard_products: []const Product = &.{ .{
-    .friendly_name_id = 0,
-    .code_name = "N0Q".*,
-    .tilt_digit_index = 1,
-    .tilt_levels = 4,
-}, .{
-    .friendly_name_id = 1,
-    .code_name = "NOU".*,
-    .tilt_digit_index = 1,
-    .tilt_levels = 4,
-}, .{
-    .friendly_name_id = 2,
-    .code_name = "N0C".*,
-    .tilt_digit_index = 1,
-    .tilt_levels = 4,
-}, .{
-    .friendly_name_id = 3,
-    .code_name = "EET".*,
-    .tilt_digit_index = 0,
-    .tilt_levels = 1,
-}, .{
-    .friendly_name_id = 4,
-    .code_name = "N0X".*,
-    .tilt_digit_index = 1,
-    .tilt_levels = 4,
-} };
+pub const standard_products: []const Product = &.{
+    .{
+        .friendly_name_id = 0,
+        .code_name = "N0Q".*,
+        .tilt_digit_index = 1,
+        .tilt_levels = 4,
+    },
+    .{
+        .friendly_name_id = 1,
+        .code_name = "NOU".*,
+        .tilt_digit_index = 1,
+        .tilt_levels = 4,
+    },
+    .{
+        .friendly_name_id = 2,
+        .code_name = "N0C".*,
+        .tilt_digit_index = 1,
+        .tilt_levels = 4,
+    },
+    .{
+        .friendly_name_id = 3,
+        .code_name = "EET".*,
+        .tilt_digit_index = 0,
+        .tilt_levels = 1,
+    },
+    .{
+        .friendly_name_id = 4,
+        .code_name = "N0X".*,
+        .tilt_digit_index = 1,
+        .tilt_levels = 4,
+    },
+    .{
+        .friendly_name_id = 5,
+        .code_name = "N0K".*,
+        .tilt_digit_index = 1,
+        .tilt_levels = 4,
+    },
+};
 
 pub const tdwr_products: []const Product = &.{
     .{

--- a/src/ui/color_tables/definitions.zig
+++ b/src/ui/color_tables/definitions.zig
@@ -21,6 +21,7 @@ pub const ProductAssociation = enum {
     CorrelationCoefficient,
     EnhancedEchoTops,
     DifferentialReflectivity,
+    SpecificDifferentialPhase,
 };
 
 pub const ProductCodeToAssociation = std.StaticStringMap(ProductAssociation).initComptime(
@@ -30,6 +31,7 @@ pub const ProductCodeToAssociation = std.StaticStringMap(ProductAssociation).ini
         .{ "CC", .CorrelationCoefficient },
         .{ "EET", .EnhancedEchoTops },
         .{ "DR", .DifferentialReflectivity },
+        .{ "SDP", .SpecificDifferentialPhase },
     },
 );
 
@@ -42,6 +44,7 @@ pub const Ranges: [@typeInfo(ProductAssociation).@"enum".fields.len]struct { f32
     .{ 0.2, 1.05 },
     .{ 0.0, 75.0 },
     .{ -8.0, 8.0 },
+    .{ 0.0, 45.0 },
 };
 
 pub const number_of_products = std.enums.values(ProductAssociation).len;

--- a/src/ui/nexrad_layer.zig
+++ b/src/ui/nexrad_layer.zig
@@ -200,7 +200,7 @@ pub const NexradLayer = struct {
         self.radar_longitude = radar_data.radar_longitude;
         self.radial_length_meters = switch (radar_data.product_code) {
             94 => 230000.0,
-            99, 159, 161 => 150012.1,
+            99, 59, 161, 163 => 150012.1,
             180, 182 => 44448.02,
             135 => 172236.1,
             else => 0.0,
@@ -256,6 +256,7 @@ pub const NexradLayer = struct {
             161 => .CorrelationCoefficient,
             135 => .EnhancedEchoTops,
             159 => .DifferentialReflectivity,
+            163 => .SpecificDifferentialPhase,
             else => .BaseReflectivity,
         };
 


### PR DESCRIPTION
Adds specific differential phase product. The color table leaves a lot to be desired. I might change it out in the future.